### PR TITLE
fixed dependency expression issue in content.js

### DIFF
--- a/src/content.js
+++ b/src/content.js
@@ -2,18 +2,17 @@ import slugify from 'underscore.string/slugify'
 var allContent = require.context('./content', false, /\.md$/)
 
 const metadata = {
-  name: "Crisisbox",
-  blurb: "a rapid response toolkit",
+  name: 'Crisisbox',
+  blurb: 'a rapid response toolkit'
 }
 
 var pageContent = {};
-allContent.keys().map(function(key, i) {
-  var modName = key.split('.md')[0].split('./')[1]
-  var modPath = './content/'+ key.split('./')[1]
-  var modSlug = slugify(modName)
+console.log(allContent)
+allContent.keys().map(function(key) {
+  var md = allContent(key)
+  var modSlug = slugify(key.split('.md')[0].split('./')[1])
   // console.log(i,"|»", modSlug)
   // there maybe better ways to do this, but hey, its working.
-  var md = require(modPath)
   pageContent[modSlug] = md
 })
 


### PR DESCRIPTION
We had an issue because we were dynamically requiring content rather than consistently using the webpack context creation process both for finding out filenames and for loading their content as modules. Resolved and reduced some of the complexity of content.js.